### PR TITLE
port vehicle_launch

### DIFF
--- a/vehicle_launch/CMakeLists.txt
+++ b/vehicle_launch/CMakeLists.txt
@@ -1,15 +1,15 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(vehicle_launch)
 
 add_compile_options(-std=c++14)
 
-find_package(catkin REQUIRED)
+find_package(ament_cmake_auto REQUIRED)
+find_package(xacro REQUIRED)
 
-catkin_package()
+ament_auto_find_build_dependencies()
 
-install(DIRECTORY
+ament_auto_package(INSTALL_TO_SHARE
     launch
     config
     urdf
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )

--- a/vehicle_launch/launch/vehicle.launch.xml
+++ b/vehicle_launch/launch/vehicle.launch.xml
@@ -5,20 +5,22 @@
 
   <arg name="initial_engage_state" default="true"/>
   <arg name="simulation" default="false" />
-  <arg name ="vehicle_id" value="$(optenv VEHICLE_ID default)" />
+  <arg name ="vehicle_id" default="$(env VEHICLE_ID default)" />
 
   <!-- vehicle description -->
-  <include file="$(find vehicle_launch)/launch/vehicle_description.launch">
-    <arg name="vehicle_model" value="$(arg vehicle_model)"/>
-    <arg name="sensor_model" value="$(arg sensor_model)"/>
-    <arg name="vehicle_id" value="$(arg vehicle_id)"/>
-  </include>
+  <group>
+    <include file="$(find-pkg-share vehicle_launch)/launch/vehicle_description.launch.xml">
+      <arg name="vehicle_model" value="$(var vehicle_model)"/>
+      <arg name="sensor_model" value="$(var sensor_model)"/>
+      <arg name="vehicle_id" value="$(var vehicle_id)"/>
+    </include>
+  </group>
 
   <!-- vehicle interface -->
-  <include file="$(find vehicle_launch)/launch/vehicle_interface.launch">
-    <arg name="initial_engage_state" value="$(arg initial_engage_state)"/>
-    <arg name="simulation" value="$(arg simulation)"/>
-    <arg name="vehicle_model" value="$(arg vehicle_model)"/>
-    <arg name="vehicle_id" value="$(arg vehicle_id)"/>
+  <include file="$(find-pkg-share vehicle_launch)/launch/vehicle_interface.launch.xml">
+    <arg name="initial_engage_state" value="$(var initial_engage_state)"/>
+    <arg name="simulation" value="$(var simulation)"/>
+    <arg name="vehicle_model" value="$(var vehicle_model)"/>
+    <arg name="vehicle_id" value="$(var vehicle_id)"/>
   </include>
 </launch>

--- a/vehicle_launch/launch/vehicle_description.launch.xml
+++ b/vehicle_launch/launch/vehicle_description.launch.xml
@@ -3,22 +3,14 @@
   <arg name="sensor_model"/>
   <arg name="vehicle_model"/>
 
-  <arg name ="vehicle_id" />
+  <arg name ="vehicle_id"/>
 
-  <arg name="model" value="$(find vehicle_launch)/urdf/vehicle.xacro"/>
-
-  <param name="robot_description" command="$(find xacro)/xacro --inorder $(arg model) vehicle_model:=$(arg vehicle_model) sensor_model:=$(arg sensor_model) config_dir:=$(find vehicle_launch)/config/$(arg vehicle_id)/$(arg sensor_model)"/>
-
-  <group ns="/vehicle_info">
-    <rosparam file="$(eval find(arg('vehicle_model')+'_description')+'/config/vehicle_info.yaml')" command="load"/>
-    <node name="additional_vehicle_info_generator" pkg="additional_vehicle_info_generator" type="additional_vehicle_info_generator" output="log"/>
-
-    <group ns="mirror">
-      <rosparam file="$(eval find(arg('vehicle_model')+'_description')+'/config/mirror.yaml')" command="load"/>
-    </group>
-  </group>
 
   <!-- tf publisher -->
-  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
+  <arg name="model" default="$(find-pkg-share vehicle_launch)/urdf/vehicle.xacro"/>
+  <arg name="config_dir" default="$(find-pkg-share vehicle_launch)/config/$(var vehicle_id)/$(var sensor_model)"/>
+  <node name="robot_state_publisher" pkg="robot_state_publisher" exec="robot_state_publisher">
+    <param name="robot_description" value="$(command 'xacro $(var model) vehicle_model:=$(var vehicle_model) sensor_model:=$(var sensor_model) config_dir:=$(var config_dir)')"/>
+  </node>
 
 </launch>

--- a/vehicle_launch/launch/vehicle_interface.launch.xml
+++ b/vehicle_launch/launch/vehicle_interface.launch.xml
@@ -1,19 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
-  <arg name="simulation" />
-  <arg name="vehicle_model" />
-  <arg name="vehicle_id" />
+  <arg name="simulation"/>
+  <arg name="vehicle_model"/>
+  <arg name="vehicle_id"/>
   <arg name="initial_engage_state" default="true"/>
 
+  <arg name="vehicle_model_pkg" default="$(find-pkg-share $(var vehicle_model)_description)"/>
+
+
   <!-- simulation mode -->
-  <group if="$(eval simulation==true)">
-    <arg name="simulator_model" value="$(eval find(arg('vehicle_model')+'_description')+'/config/simulator_model.yaml')" />
-    <include file="$(find simple_planning_simulator)/launch/simple_planning_simulator.launch" pass_all_args="true"/>
+  <group if="$(var simulation)">
+    <arg name="simulator_model" default="$(var vehicle_model_pkg)/config/simulator_model.param.yaml" />
+    <include file="$(find-pkg-share simple_planning_simulator)/launch/simple_planning_simulator.launch.xml" pass_all_args="true"/>
   </group>
 
   <!-- real mode -->
-  <group unless="$(eval simulation==true)">
-    <include file="$(eval find(arg('vehicle_model')+'_description')+'/launch/vehicle_interface.launch')" >
+  <group unless="$(var simulation)">
+    <include file="$(var vehicle_model_pkg)/launch/vehicle_interface.launch.xml">
     </include>
   </group>
 </launch>

--- a/vehicle_launch/package.xml
+++ b/vehicle_launch/package.xml
@@ -8,14 +8,17 @@
   <license>Apache2</license>
 
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+
+  <exec_depend>xacro</exec_depend>
+
   <exec_depend>camera_description</exec_depend>
   <exec_depend>imu_description</exec_depend>
   <exec_depend>livox_description</exec_depend>
   <exec_depend>velodyne_description</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
 
-  <depend>roscpp</depend>
   <export>
+    <build_type>ament_cmake</build_type>
   </export>
 </package>


### PR DESCRIPTION
## Description
porting vehicle_launch to ros2

Change xacro command:
`<param name="robot_description" command="$(find xacro)/xacro --inorder $(arg model) ` to
`<param name="robot_description" value="$(command 'xacro $(var model) `
(--inorder option is default in ros2)


## How to run

After https://github.com/tier4/lexus_description.iv.universe/pull/4 is merged,

```
ros2 launch vehicle_launch vehicle.launch.xml sensor_model:=aip_xx1 vehicle_model:=lexus simulation:=true
```

**Note** Cannot run with `simulation:=false` since `pacmod3` is not released for foxy. 