### PR TITLE
Fix ci

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -17,6 +17,11 @@ jobs:
     - name: Check out repo
       uses: actions/checkout@v2
 
+    - name: Clone dependency packages
+      run: |
+        mkdir dependency_ws
+        vcs import dependency_ws < build_depends.repos
+
     - name: Install missing dependencies
       run: |
         sudo apt update

--- a/build_depends.repos
+++ b/build_depends.repos
@@ -1,0 +1,9 @@
+repositories:
+  description/sensor/velodyne_simulator:
+    type: git
+    url: https://github.com/tier4/velodyne_simulator.git
+    version: ros2
+  description/sensor/sensor_description:
+    type: git
+    url: https://github.com/tier4/sensor_description.iv.universe.git
+    version: ros2


### PR DESCRIPTION
Add build_depends.repos to add dependent packages.
Required for https://github.com/tier4/autoware_launcher.iv.universe/pull/4/files