### PR TITLE
Only build the launch subset of packages

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -36,6 +36,7 @@ jobs:
     - name: Build
       run: |
         . /opt/ros/foxy/setup.sh
+        colcon build \
           --event-handlers console_cohesion+ \
           --packages-ignore \
             autoware_launch \

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -36,11 +36,35 @@ jobs:
     - name: Build
       run: |
         . /opt/ros/foxy/setup.sh
-        colcon build --event-handlers console_cohesion+
+          --event-handlers console_cohesion+ \
+          --packages-ignore \
+            autoware_launch \
+            integration_launch \
+            localization_launch \
+            perception_launch \
+            planning_launch \
+            sensing_launch \
+            system_launch \
+          --packages-up-to \
+            control_launch \
+            map_launch \
+            vehicle_launch
 
     - name: Run tests
       run: |
         . /opt/ros/foxy/setup.sh
         colcon test \
+          --return-code-on-test-failure \
           --event-handlers console_cohesion+ \
-          --return-code-on-test-failure
+          --packages-ignore \
+            autoware_launch \
+            integration_launch \
+            localization_launch \
+            perception_launch \
+            planning_launch \
+            sensing_launch \
+            system_launch \
+          --packages-up-to \
+            control_launch \
+            map_launch \
+            vehicle_launch


### PR DESCRIPTION
This should reduce CI times, as we will only build the launch packages and their dependencies, instead of the entire workspace.