### PR TITLE
Add usb_cam as another dependency

### DIFF
--- a/build_depends.repos
+++ b/build_depends.repos
@@ -31,3 +31,7 @@ repositories:
     type: git
     url: https://github.com/tier4/Pilot.Auto.git
     version: ros2
+  vendor/usb_cam:
+    type: git
+    url: https://github.com/flynneva/usb_cam.git
+    version: foxy


### PR DESCRIPTION
In porting `sensing_launch` in this [PR](https://github.com/tier4/autoware_launcher.iv.universe/pull/14), I just stumbled over a dependency on `usb_cam`. Unfortunately there is no official ros2 version yet ([PR in progress](https://github.com/ros-drivers/usb_cam/pull/132)), so  for the time being, I add the branch as a dependency here so its CI works

Same change for overal `ArchitectureProposal` repo:

https://github.com/tier4/AutowareArchitectureProposal/pull/134

@mitsudome-r @esteve 