### PR TITLE
Pass down vehicle_model to lower-level launch files

### DIFF
--- a/planning_launch/launch/planning.launch.xml
+++ b/planning_launch/launch/planning.launch.xml
@@ -1,4 +1,5 @@
 <launch>
+  <arg name="vehicle_model" />
   <!-- planning module -->
   <group>
     <push-ros-namespace namespace="planning"/>
@@ -6,6 +7,7 @@
     <group>
       <push-ros-namespace namespace="mission_planning"/>
       <include file="$(find-pkg-share planning_launch)/launch/mission_planning/mission_planning.launch.xml">
+        <arg name="vehicle_model" value="$(var vehicle_model)" />
       </include>
     </group>
 
@@ -13,6 +15,7 @@
     <group>
       <push-ros-namespace namespace="scenario_planning"/>
       <include file="$(find-pkg-share planning_launch)/launch/scenario_planning/scenario_planning.launch.xml">
+        <arg name="vehicle_model" value="$(var vehicle_model)" />
       </include>
     </group>
   </group>

--- a/planning_launch/launch/scenario_planning/lane_driving.launch.xml
+++ b/planning_launch/launch/scenario_planning/lane_driving.launch.xml
@@ -1,4 +1,5 @@
 <launch>
+  <arg name="vehicle_model" />
 
   <!-- lane_driving scenario -->
   <group>
@@ -7,6 +8,7 @@
     <group>
       <push-ros-namespace namespace="behavior_planning"/>
       <include file="$(find-pkg-share planning_launch)/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.xml">
+        <arg name="vehicle_model" value="$(var vehicle_model)" />
       </include>
     </group>
 
@@ -14,6 +16,7 @@
     <group>
       <push-ros-namespace namespace="motion_planning"/>
       <include file="$(find-pkg-share planning_launch)/launch/scenario_planning/lane_driving/motion_planning/motion_planning.launch.xml">
+        <arg name="vehicle_model" value="$(var vehicle_model)" />
       </include>
     </group>
   </group>

--- a/planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.xml
+++ b/planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.xml
@@ -1,6 +1,7 @@
 <launch>
   <arg name="input_route_topic_name" default="/planning/mission_planning/route" />
   <arg name="map_topic_name" default="/map/vector_map" />
+  <arg name="vehicle_model" />
 
   <node pkg="lane_change_planner" exec="lane_change_planner" name="lane_change_planner" output="screen">
     <remap from="input/route" to="$(var input_route_topic_name)" />
@@ -43,6 +44,7 @@
   </node>
 
   <include file="$(find-pkg-share behavior_velocity_planner)/launch/behavior_velocity_planner.launch.xml">
+    <arg name="vehicle_model" value="$(var vehicle_model)" />
   </include>
 
 </launch>

--- a/planning_launch/launch/scenario_planning/lane_driving/motion_planning/motion_planning.launch.xml
+++ b/planning_launch/launch/scenario_planning/lane_driving/motion_planning/motion_planning.launch.xml
@@ -1,5 +1,6 @@
 <launch>
   <arg name="input_path_topic" default="/planning/scenario_planning/lane_driving/behavior_planning/path" />
+  <arg name="vehicle_model" />
 
   <!-- path planning for avoiding obstacle with dynamic object info -->
   <group>
@@ -7,7 +8,8 @@
       <arg name="param_path" value="$(find-pkg-share planning_launch)/config/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/obstacle_avoidance_planner.yaml"/>
       <arg name="input_path_topic" value="$(var input_path_topic)" />
       <arg name="output_path_topic" value="obstacle_avoidance_planner/trajectory" />
-      </include>
+      <arg name="vehicle_model" value="$(var vehicle_model)" />
+    </include>
   </group>
 
 
@@ -16,7 +18,8 @@
     <include file="$(find-pkg-share surround_obstacle_checker)/launch/surround_obstacle_checker.launch.xml">
       <arg name="input_trajectory" value="obstacle_avoidance_planner/trajectory" />
       <arg name="output_trajectory" value="surround_obstacle_checker/trajectory" />
-      </include>
+      <arg name="vehicle_model" value="$(var vehicle_model)" />
+    </include>
   </group>
 
 
@@ -27,7 +30,8 @@
       <arg name="input_trajectory" value="surround_obstacle_checker/trajectory" />
       <arg name="input_pointcloud" value="/sensing/lidar/no_ground/pointcloud" />
       <arg name="output_trajectory" value="/planning/scenario_planning/lane_driving/trajectory" />
-      </include>
+      <arg name="vehicle_model" value="$(var vehicle_model)" />
+    </include>
   </group>
 
 </launch>


### PR DESCRIPTION
As far as I understand, this is needed because the vehicle model is set at the top level.