### PR TITLE
ROS2 Linting: control_launch

### DIFF
--- a/control_launch/CMakeLists.txt
+++ b/control_launch/CMakeLists.txt
@@ -11,6 +11,11 @@ endif()
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
 ament_auto_package(
   INSTALL_TO_SHARE
   config

--- a/control_launch/package.xml
+++ b/control_launch/package.xml
@@ -13,7 +13,7 @@
 
   <exec_depend>latlon_muxer</exec_depend>
   <exec_depend>mpc_follower</exec_depend>
-  <!-- <exec_depend>pure_pursuit</exec_depend> -->
+  <exec_depend>pure_pursuit</exec_depend>
   <exec_depend>remote_cmd_converter</exec_depend>
   <exec_depend>shift_decider</exec_depend>
   <exec_depend>vehicle_cmd_gate</exec_depend>

--- a/control_launch/package.xml
+++ b/control_launch/package.xml
@@ -11,13 +11,13 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <exec_depend>pure_pursuit</exec_depend>
-  <exec_depend>mpc_follower</exec_depend>
   <exec_depend>latlon_muxer</exec_depend>
-  <exec_depend>velocity_controller</exec_depend>
+  <exec_depend>mpc_follower</exec_depend>
+  <exec_depend>pure_pursuit</exec_depend>
+  <exec_depend>remote_cmd_converter</exec_depend>
   <exec_depend>shift_decider</exec_depend>
   <exec_depend>vehicle_cmd_gate</exec_depend>
-  <exec_depend>remote_cmd_converter</exec_depend>
+  <exec_depend>velocity_controller</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/control_launch/package.xml
+++ b/control_launch/package.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>control_launch</name>
   <version>0.1.0</version>
   <description>The control_launch package</description>
@@ -9,6 +10,17 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
+
+  <exec_depend>pure_pursuit</exec_depend>
+  <exec_depend>mpc_follower</exec_depend>
+  <exec_depend>latlon_muxer</exec_depend>
+  <exec_depend>velocity_controller</exec_depend>
+  <exec_depend>shift_decider</exec_depend>
+  <exec_depend>vehicle_cmd_gate</exec_depend>
+  <exec_depend>remote_cmd_converter</exec_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/control_launch/package.xml
+++ b/control_launch/package.xml
@@ -13,7 +13,7 @@
 
   <exec_depend>latlon_muxer</exec_depend>
   <exec_depend>mpc_follower</exec_depend>
-  <exec_depend>pure_pursuit</exec_depend>
+  <!-- <exec_depend>pure_pursuit</exec_depend> -->
   <exec_depend>remote_cmd_converter</exec_depend>
   <exec_depend>shift_decider</exec_depend>
   <exec_depend>vehicle_cmd_gate</exec_depend>


### PR DESCRIPTION
## Summary

Added linters to the control launch `ament_lint_common`. Not sure if this is necessary but I also add the package dependencies that were missing before. I know that the descriptions packages did not require linters but I wasn't sure about these launch packages if they benefit from adding `ament_lint_common`.

Note: It seems like `pure_pursuit` is not ported yet but is a dependency in this package.