### PR TITLE
ROS2 Linting: vehicle_launch

### DIFF
--- a/vehicle_launch/CMakeLists.txt
+++ b/vehicle_launch/CMakeLists.txt
@@ -8,6 +8,11 @@ find_package(xacro REQUIRED)
 
 ament_auto_find_build_dependencies()
 
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
 ament_auto_package(INSTALL_TO_SHARE
     launch
     config

--- a/vehicle_launch/package.xml
+++ b/vehicle_launch/package.xml
@@ -5,7 +5,7 @@
   <description>The vehicle_launch package</description>
 
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>
-  <license>Apache2</license>
+  <license>Apache License 2.0</license>
 
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
@@ -17,6 +17,10 @@
   <exec_depend>livox_description</exec_depend>
   <exec_depend>velodyne_description</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>simple_planning_simulator</exec_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
## Summary

Added `ament_lint_common` linter tests and adding in missing exec dependencies. Once again, not sure if this change is necessary.