### PR TITLE
[perception_launch] fix perception_launch

### DIFF
--- a/perception_launch/launch/object_recognition/prediction/prediction.launch.xml
+++ b/perception_launch/launch/object_recognition/prediction/prediction.launch.xml
@@ -5,7 +5,7 @@
 
   <group if="$(var use_vector_map)">
     <include file="$(find-pkg-share map_based_prediction)/launch/map_based_prediction.launch.xml">
-      <remap from="objects" to="/perception/object_recognition/objects"/>
+      <arg name="output_topic" value="/perception/object_recognition/objects"/>
     </include>
   </group>
   <group unless="$(var use_vector_map)">
@@ -18,6 +18,6 @@
   <include file="$(find-pkg-share dynamic_object_visualization)/launch/dynamic_object_visualizer.launch.xml">
     <arg name="input" value="/perception/object_recognition/objects"/>
     <arg name="with_feature" value="false"/>
-    <arg name="only_known_objects" default="true"/>
+    <arg name="only_known_objects" value="true"/>
   </include>
 </launch>

--- a/perception_launch/launch/object_recognition/tracking/tracking.launch.xml
+++ b/perception_launch/launch/object_recognition/tracking/tracking.launch.xml
@@ -7,6 +7,6 @@
   <include file="$(find-pkg-share dynamic_object_visualization)/launch/dynamic_object_visualizer.launch.xml">
     <arg name="input" value="objects"/>
     <arg name="with_feature" value="false"/>
-    <arg name="only_known_objects" default="true"/>
+    <arg name="only_known_objects" value="true"/>
   </include>
 </launch>


### PR DESCRIPTION
Fix perception_launch to use `arg` instead of `remap` tags to rename topics since `remap` tag is not supported in `include` tag anymore. 