### PR TITLE
ROS2 Linting: perception_launch

### DIFF
--- a/perception_launch/CMakeLists.txt
+++ b/perception_launch/CMakeLists.txt
@@ -4,6 +4,11 @@ project(perception_launch)
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
 ament_auto_package(
   INSTALL_TO_SHARE
   launch

--- a/perception_launch/package.xml
+++ b/perception_launch/package.xml
@@ -10,13 +10,16 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <depend>dynamic_object_visualization</depend>
-  <depend>image_transport_plugins</depend>
-  <!--
-    <build_depend>euclidean_cluster</build_depend>
-    <build_depend>pointcloud_to_laserscan</build_depend>
-    <build_depend>shape_estimation</build_depend>
-  -->
+  <exec_depend>dynamic_object_visualization</exec_depend>
+  <exec_depend>lidar_apollo_instance_segmentation</exec_depend>
+  <exec_depend>euclidean_cluster</exec_depend>
+  <exec_depend>tensorrt_yolo3</exec_depend>
+  <exec_depend>roi_cluster_fusion</exec_depend>
+  <exec_depend>cluster_data_association</exec_depend>
+  <exec_depend>shape_estimation</exec_depend>
+  <exec_depend>map_based_prediction</exec_depend>
+  <exec_depend>naive_path_prediction</exec_depend>
+  <exec_depend>multi_object_tracker</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/perception_launch/package.xml
+++ b/perception_launch/package.xml
@@ -10,16 +10,16 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <exec_depend>dynamic_object_visualization</exec_depend>
-  <exec_depend>lidar_apollo_instance_segmentation</exec_depend>
-  <exec_depend>euclidean_cluster</exec_depend>
-  <exec_depend>tensorrt_yolo3</exec_depend>
-  <exec_depend>roi_cluster_fusion</exec_depend>
   <exec_depend>cluster_data_association</exec_depend>
-  <exec_depend>shape_estimation</exec_depend>
+  <exec_depend>dynamic_object_visualization</exec_depend>
+  <exec_depend>euclidean_cluster</exec_depend>
+  <exec_depend>lidar_apollo_instance_segmentation</exec_depend>
   <exec_depend>map_based_prediction</exec_depend>
-  <exec_depend>naive_path_prediction</exec_depend>
   <exec_depend>multi_object_tracker</exec_depend>
+  <exec_depend>naive_path_prediction</exec_depend>
+  <exec_depend>roi_cluster_fusion</exec_depend>
+  <exec_depend>shape_estimation</exec_depend>
+  <exec_depend>tensorrt_yolo3</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
## Summary

Lint of `perception_launch` package - the linter test dependencies were already added but tests themselves were not added in the Cmake. Added missing dependencies: two of which are still being ported: 
 - [x] https://github.com/tier4/Pilot.Auto/pull/118
 - [x] https://github.com/tier4/Pilot.Auto/pull/120