### PR TITLE
Use Livox vendor package

### DIFF
--- a/build_depends.repos
+++ b/build_depends.repos
@@ -33,7 +33,7 @@ repositories:
     version: ros2
   vendor/livox-driver:
     type: git
-    url: https://github.com/fred-apex-ai/livox_ros2_driver.git
+    url: https://github.com/esteve/livox_ros2_driver.git
     version: master
   vendor/usb_cam:
     type: git

--- a/build_depends.repos
+++ b/build_depends.repos
@@ -33,7 +33,7 @@ repositories:
     version: ros2
   vendor/livox-driver:
     type: git
-    url: https://github.com/esteve/livox_ros2_driver.git
+    url: https://github.com/Livox-SDK/livox_ros2_driver.git
     version: master
   vendor/usb_cam:
     type: git


### PR DESCRIPTION
This uses the forked Livox driver from https://github.com/esteve/livox_ros2_driver/ that uses the vendor package from https://github.com/tier4/livox_sdk_vendor/ to fetch and install the Livox SDK

Update: all the changes have been accepted upstream, switching to https://github.com/Livox-SDK/livox_ros2_driver instead