### PR TITLE
Fix typo in control launch

### DIFF
--- a/control_launch/config/mpc_follower/mpc_follower.param.yaml
+++ b/control_launch/config/mpc_follower/mpc_follower.param.yaml
@@ -5,8 +5,8 @@
     traj_resample_dist: 0.1         # path resampling interval [m]
     enable_yaw_recalculation: false # flag for recalculation of yaw angle after resampling
     use_steer_prediction: false     # flag for using steer prediction (do not use steer measurement)
-    admisible_position_error: 5.0   # stop mpc calculation when error is larger than the following value
-    admisible_yaw_error_: 1.57      # stop mpc calculation when error is larger than the following value
+    admissible_position_error: 5.0  # stop mpc calculation when error is larger than the following value
+    admissible_yaw_error_: 1.57     # stop mpc calculation when error is larger than the following value
 
     # -- path smoothing --
     enable_path_smoothing: false   # flag for path smoothing
@@ -42,7 +42,7 @@
     # -- vehicle model --
     vehicle_model_type: "kinematics" # vehicle model type for mpc prediction. option is kinematics, kinematics_no_delay, and dynamics
     input_delay: 0.24     # steering input delay time for delay compensation
-    vehicle_model_steer_tau: 0.3     # steering dynamics time constant (1d approzimation) [s]
+    vehicle_model_steer_tau: 0.3     # steering dynamics time constant (1d approximation) [s]
     steer_lim_deg: 40.0              # steering angle limit [deg]
     steer_rate_lim_dps: 600.0        # steering angle rate limit [deg/s]
     acceleration_limit: 2.0          # acceleration limit for trajectory velocity modification [m/ss]

--- a/control_launch/config/mpc_follower/mpc_follower.param.yaml
+++ b/control_launch/config/mpc_follower/mpc_follower.param.yaml
@@ -6,7 +6,7 @@
     enable_yaw_recalculation: false # flag for recalculation of yaw angle after resampling
     use_steer_prediction: false     # flag for using steer prediction (do not use steer measurement)
     admissible_position_error: 5.0  # stop mpc calculation when error is larger than the following value
-    admissible_yaw_error_: 1.57     # stop mpc calculation when error is larger than the following value
+    admissible_yaw_error_rad: 1.57  # stop mpc calculation when error is larger than the following value
 
     # -- path smoothing --
     enable_path_smoothing: false   # flag for path smoothing


### PR DESCRIPTION
Fix typo in the control launch file.
Please merge this with the following pull request simultaneously.
https://github.com/tier4/AutowareArchitectureProposal.iv/pull/428