### PR TITLE
Ros2 vehicle info param server

### DIFF
--- a/autoware_launch/launch/autoware.launch.xml
+++ b/autoware_launch/launch/autoware.launch.xml
@@ -46,12 +46,10 @@
 
   <!-- Planning -->
   <include file="$(find-pkg-share planning_launch)/launch/planning.launch.xml">
-    <arg name="vehicle_param_file" value="$(find-pkg-share $(var vehicle_model)_description)/config/vehicle_info.param.yaml"/>
   </include>
 
   <!-- Control -->
   <include file="$(find-pkg-share control_launch)/launch/control.launch.xml">
-    <arg name="vehicle_param_file" value="$(find-pkg-share $(var vehicle_model)_description)/config/vehicle_info.param.yaml"/>
     <arg name="lateral_controller_mode" value="mpc_follower" doc="options: mpc_follower, pure_pursuit"/>
   </include>
 

--- a/autoware_launch/launch/logging_simulator.launch.xml
+++ b/autoware_launch/launch/logging_simulator.launch.xml
@@ -57,12 +57,10 @@
 
   <!-- Planning -->
   <include file="$(find-pkg-share planning_launch)/launch/planning.launch.xml" if="$(var planning)">
-    <arg name="vehicle_param_file" value="$(find-pkg-share $(var vehicle_model)_description)/config/vehicle_info.param.yaml"/>
   </include>
 
   <!-- Control -->
   <include file="$(find-pkg-share control_launch)/launch/control.launch.xml" if="$(var control)">
-    <arg name="vehicle_param_file" value="$(find-pkg-share $(var vehicle_model)_description)/config/vehicle_info.param.yaml"/>
     <arg name="lateral_controller_mode" value="mpc_follower" doc="options: mpc_follower, pure_pursuit"/>
   </include>
 

--- a/autoware_launch/launch/planning_simulator.launch.xml
+++ b/autoware_launch/launch/planning_simulator.launch.xml
@@ -43,12 +43,10 @@
 
   <!-- Planning -->
   <include file="$(find-pkg-share planning_launch)/launch/planning.launch.xml">
-    <arg name="vehicle_param_file" value="$(find-pkg-share $(var vehicle_model)_description)/config/vehicle_info.param.yaml"/>
   </include>
 
   <!-- Control -->
   <include file="$(find-pkg-share control_launch)/launch/control.launch.xml">
-    <arg name="vehicle_param_file" value="$(find-pkg-share $(var vehicle_model)_description)/config/vehicle_info.param.yaml"/>
     <arg name="lateral_controller_mode" value="mpc_follower" doc="options: mpc_follower, pure_pursuit"/>
   </include>
 

--- a/control_launch/launch/control.launch.xml
+++ b/control_launch/launch/control.launch.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 
 <launch>
-  <arg name="vehicle_param_file" />
 
   <!-- common parameters -->
   <arg name="lateral_controller_mode" default="mpc_follower" doc="options: mpc_follower, pure_pursuit"/>
@@ -24,21 +23,18 @@
       <group if="$(eval &quot;'$(var lateral_controller_mode)'=='mpc_follower'&quot;)">
         <include file="$(find-pkg-share mpc_follower)/launch/mpc_follower.launch.xml">
           <arg name="mpc_follower_param_path" value="$(var mpc_follower_param_path)" />
-          <arg name="vehicle_param_file" value="$(var vehicle_param_file)" />
         </include>
       </group>
 
       <group if="$(eval &quot;'$(var lateral_controller_mode)'=='pure_pursuit'&quot;)">
         <include file="$(find-pkg-share pure_pursuit)/launch/pure_pursuit.launch.xml">
           <arg name="pure_pursuit_param_path" value="$(var pure_pursuit_param_path)" />
-          <arg name="vehicle_param_file" value="$(var vehicle_param_file)" />
         </include>
       </group>
 
       <!-- longitudinal controller -->
       <include file="$(find-pkg-share velocity_controller)/launch/velocity_controller.launch.xml">
         <arg name="velocity_controller_param_path" value="$(var velocity_controller_param_path)"/>
-        <arg name="vehicle_param_file" value="$(var vehicle_param_file)" />
       </include>
 
       <!-- latlon coupler -->
@@ -51,7 +47,6 @@
 
       <!-- lane departure checker -->
       <include file="$(find-pkg-share lane_departure_checker)/launch/lane_departure_checker.launch.xml">
-        <arg name="vehicle_param_file" value="$(var vehicle_param_file)" />
       </include>
     </group>
 
@@ -61,7 +56,6 @@
 
     <!-- vehicle cmd gate -->
     <include file="$(find-pkg-share vehicle_cmd_gate)/launch/vehicle_cmd_gate.launch.xml">
-      <arg name="vehicle_param_file" value="$(var vehicle_param_file)" />
       <arg name="config_file" value="$(var vehicle_cmd_gate_param_path)"/>
       <arg name="use_emergency_handling" value="false"/>
       <arg name="use_external_emergency_stop" value="true"/>

--- a/planning_launch/launch/planning.launch.xml
+++ b/planning_launch/launch/planning.launch.xml
@@ -1,5 +1,4 @@
 <launch>
-  <arg name="vehicle_param_file" />
   <!-- planning module -->
   <group>
     <push-ros-namespace namespace="planning"/>
@@ -14,7 +13,6 @@
     <group>
       <push-ros-namespace namespace="scenario_planning"/>
       <include file="$(find-pkg-share planning_launch)/launch/scenario_planning/scenario_planning.launch.xml">
-        <arg name="vehicle_param_file" value="$(var vehicle_param_file)" />
       </include>
     </group>
   </group>

--- a/planning_launch/launch/scenario_planning/lane_driving.launch.xml
+++ b/planning_launch/launch/scenario_planning/lane_driving.launch.xml
@@ -1,5 +1,4 @@
 <launch>
-  <arg name="vehicle_param_file" />
 
   <!-- lane_driving scenario -->
   <group>
@@ -8,7 +7,6 @@
     <group>
       <push-ros-namespace namespace="behavior_planning"/>
       <include file="$(find-pkg-share planning_launch)/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.xml">
-        <arg name="vehicle_param_file" value="$(var vehicle_param_file)" />
       </include>
     </group>
 
@@ -16,7 +14,6 @@
     <group>
       <push-ros-namespace namespace="motion_planning"/>
       <include file="$(find-pkg-share planning_launch)/launch/scenario_planning/lane_driving/motion_planning/motion_planning.launch.xml">
-        <arg name="vehicle_param_file" value="$(var vehicle_param_file)" />
       </include>
     </group>
   </group>

--- a/planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.xml
+++ b/planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.xml
@@ -1,7 +1,6 @@
 <launch>
   <arg name="input_route_topic_name" default="/planning/mission_planning/route" />
   <arg name="map_topic_name" default="/map/vector_map" />
-  <arg name="vehicle_param_file" />
 
   <node pkg="lane_change_planner" exec="lane_change_planner" name="lane_change_planner" output="screen">
     <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
@@ -41,7 +40,6 @@
     <param name="use_all_predicted_path" value="false" />
     <param name="refine_goal_search_radius_range" value="7.5" />
     <param name="enable_blocked_by_obstacle" value="false" />
-    <param from="$(var vehicle_param_file)" />
   </node>
 
   <executable cmd="ros2 topic pub /planning/scenario_planning/lane_driving/lane_change_approval
@@ -54,11 +52,9 @@
     <remap from="output/turn_signal_cmd" to="/planning/turn_signal_decider/turn_signal_cmd" />
     <param name="lane_change_search_distance" value="30.0" />
     <param name="intersection_search_distance" value="30.0" />
-    <param from="$(var vehicle_param_file)" />
   </node>
 
   <include file="$(find-pkg-share behavior_velocity_planner)/launch/behavior_velocity_planner.launch.xml">
-    <arg name="vehicle_param_file" value="$(var vehicle_param_file)" />
   </include>
 
 </launch>

--- a/planning_launch/launch/scenario_planning/lane_driving/motion_planning/motion_planning.launch.xml
+++ b/planning_launch/launch/scenario_planning/lane_driving/motion_planning/motion_planning.launch.xml
@@ -1,6 +1,5 @@
 <launch>
   <arg name="input_path_topic" default="/planning/scenario_planning/lane_driving/behavior_planning/path" />
-  <arg name="vehicle_param_file" />
   <arg name="use_surround_obstacle_check" default="true" />
 
   <!-- path planning for avoiding obstacle with dynamic object info -->
@@ -9,7 +8,6 @@
       <arg name="param_path" value="$(find-pkg-share planning_launch)/config/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/obstacle_avoidance_planner.param.yaml"/>
       <arg name="input_path_topic" value="$(var input_path_topic)" />
       <arg name="output_path_topic" value="obstacle_avoidance_planner/trajectory" />
-      <arg name="vehicle_param_file" value="$(var vehicle_param_file)" />
     </include>
   </group>
 
@@ -19,7 +17,6 @@
     <include file="$(find-pkg-share surround_obstacle_checker)/launch/surround_obstacle_checker.launch.xml">
       <arg name="input_trajectory" value="obstacle_avoidance_planner/trajectory" />
       <arg name="output_trajectory" value="surround_obstacle_checker/trajectory" />
-      <arg name="vehicle_param_file" value="$(var vehicle_param_file)" />
       <arg name="param_path" value="$(find-pkg-share planning_launch)/config/scenario_planning/lane_driving/motion_planning/surround_obstacle_checker/surround_obstacle_checker.param.yaml"/>
     </include>
   </group>
@@ -40,7 +37,6 @@
       <arg name="input_trajectory" value="surround_obstacle_checker/trajectory" />
       <arg name="input_pointcloud" value="/sensing/lidar/no_ground/pointcloud" />
       <arg name="output_trajectory" value="/planning/scenario_planning/lane_driving/trajectory" />
-      <arg name="vehicle_param_file" value="$(var vehicle_param_file)" />
       <arg name="acc_param_file" value="$(find-pkg-share planning_launch)/config/adaptive_cruise_control.param.yaml" />
       <arg name="param_file" value="$(find-pkg-share planning_launch)/config/obstacle_stop_planner.param.yaml" />
       <arg name="enable_slow_down" value="false" />

--- a/planning_launch/launch/scenario_planning/scenario_planning.launch.xml
+++ b/planning_launch/launch/scenario_planning/scenario_planning.launch.xml
@@ -1,5 +1,4 @@
 <launch>
-  <arg name="vehicle_param_file" />
 
   <!-- scenario selector -->
   <include file="$(find-pkg-share scenario_selector)/launch/scenario_selector.launch.xml">
@@ -27,7 +26,6 @@
   <group>
     <!-- lane driving -->
     <include file="$(find-pkg-share planning_launch)/launch/scenario_planning/lane_driving.launch.xml">
-      <arg name="vehicle_param_file" value="$(var vehicle_param_file)" />
     </include>
     <!-- parking -->
     <include file="$(find-pkg-share planning_launch)/launch/scenario_planning/parking.launch.xml">

--- a/vehicle_launch/launch/vehicle.launch.xml
+++ b/vehicle_launch/launch/vehicle.launch.xml
@@ -27,7 +27,6 @@
     <arg name="initial_engage_state" value="$(var initial_engage_state)"/>
     <arg name="simulation" value="$(var simulation)"/>
     <arg name="vehicle_model" value="$(var vehicle_model)"/>
-    <arg name="vehicle_param_file" value="$(var vehicle_param_file)"/>
     <arg name="vehicle_id" value="$(var vehicle_id)"/>
   </include>
 </launch>

--- a/vehicle_launch/launch/vehicle.launch.xml
+++ b/vehicle_launch/launch/vehicle.launch.xml
@@ -8,6 +8,11 @@
   <arg name="simulation" default="false" />
   <arg name ="vehicle_id" default="$(env VEHICLE_ID default)" />
 
+  <!-- vehicle info -->
+  <include file="$(find-pkg-share vehicle_info_param_server)/launch/vehicle_info_param_server.launch.xml">
+    <arg name="config_file" value="$(var vehicle_param_file)"/>
+  </include>
+
   <!-- vehicle description -->
   <group>
     <include file="$(find-pkg-share vehicle_launch)/launch/vehicle_description.launch.xml">

--- a/vehicle_launch/launch/vehicle_interface.launch.xml
+++ b/vehicle_launch/launch/vehicle_interface.launch.xml
@@ -2,7 +2,6 @@
 <launch>
   <arg name="simulation"/>
   <arg name="vehicle_model"/>
-  <arg name="vehicle_param_file" />
   <arg name="vehicle_id"/>
   <arg name="initial_engage_state" default="true"/>
 
@@ -14,7 +13,6 @@
     <arg name="simulator_model" default="$(var vehicle_model_pkg)/config/simulator_model.param.yaml" />
     <include file="$(find-pkg-share simple_planning_simulator)/launch/simple_planning_simulator.launch.xml">
       <arg name="simulator_model" value="$(var simulator_model)"/>
-      <arg name="vehicle_param_file" value="$(var vehicle_param_file)"/>
       <arg name="initial_engage_state" value="$(var initial_engage_state)"/>
     </include>
   </group>


### PR DESCRIPTION
Add vehicle_info_param_server.
- vehicle_info_param_server node sets rosparameter for all necessary nodes.
- Delete unnecessary vehicle_param_file parameter described in Launch files.